### PR TITLE
chore: bump @loopkit/javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@loopkit/react",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "React TypeScript wrapper for @loopkit/javascript with built-in auto-tracking and comprehensive TypeScript support",
     "main": "dist/index.js",
     "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "react-dom": ">=16.8.0"
     },
     "dependencies": {
-        "@loopkit/javascript": "^1.1.3"
+        "@loopkit/javascript": "^1.1.5"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,10 +676,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@loopkit/javascript@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@loopkit/javascript/-/javascript-1.1.3.tgz#b4f1f9166b9c292372d86fc492c57becf8e6450f"
-  integrity sha512-W3GzPgGri3uOoBJSmpQr1A8WFjNpgChpT6dPAnuUXhNb8MEvdkRMk4zBvXjMbxjqQbsYE2iDoT0wNGuL7B5vKg==
+"@loopkit/javascript@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@loopkit/javascript/-/javascript-1.1.5.tgz#3b285d555ff62db6aedee9f7fdfb6e4718df9330"
+  integrity sha512-VgSYeqzow4Iu6HILBbfR30YqlGjcs6eybkQ9ZBmsRlciDPlngoRKSbqskG1qbabEO8HynCoteqBVjMYt5+39DA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
### Background
A breaking change was made to the LoopKit API where we dropped support for `sendBeacon` and we migrated the Javascript SDK to fetch with `keepalive`.

https://github.com/loopkitai/loopkit/pull/3

### Summary
* Bumped the LoopKit Javascript SDK version